### PR TITLE
Upgrade to Debian Bullseye with Salt 3003 and systemd init

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,36 +1,131 @@
-FROM debian:jessie
+FROM debian:bullseye
 
-MAINTAINER Bruno Binet <bruno.binet@helioslite.com>
+LABEL maintainer="Bruno Binet <bruno.binet@helioslite.com>"
 
-ENV DEBIAN_FRONTEND noninteractive
-ENV SALT_VERSION 2016.11
-ENV REFRESHED_AT 2017-01-31
+ENV container=docker
+ENV DEBIAN_FRONTEND=noninteractive
 
-RUN echo "deb http://repo.saltstack.com/apt/debian/8/amd64/${SALT_VERSION} jessie main" > /etc/apt/sources.list.d/salt.list
+# Switch to archive repos (bullseye is EOL) with Freexian Extended LTS for security updates
+# See: https://www.freexian.com/lts/extended/docs/debian-11-support/
+# Add both archive and Freexian repos together to avoid dependency conflicts
+RUN echo "deb https://archive.debian.org/debian bullseye main" > /etc/apt/sources.list && \
+    echo 'Acquire::Check-Valid-Until "false";' > /etc/apt/apt.conf.d/99no-check-valid
 
-ADD https://repo.saltstack.com/apt/debian/8/amd64/${SALT_VERSION}/SALTSTACK-GPG-KEY.pub /tmp/SALTSTACK-GPG-KEY.pub
-RUN echo "9e0d77c16ba1fe57dfd7f1c5c2130438  /tmp/SALTSTACK-GPG-KEY.pub" | md5sum --check
-RUN apt-key add /tmp/SALTSTACK-GPG-KEY.pub
+# First install ca-certificates and curl (needed for Freexian GPG key) with archive repo only
+RUN apt-get update && \
+    apt-get install -yq --no-install-recommends ca-certificates curl && \
+    rm -rf /var/lib/apt/lists/*
 
-RUN apt-get update && apt-get install -yq --no-install-recommends \
-  salt-master reclass salt-api python-apt python-git python-openssl \
-  python-cherrypy3 git openssh-client make
+# Add Freexian Extended LTS repo for security updates
+RUN curl -fsSL https://deb.freexian.com/extended-lts/archive-key.gpg \
+      -o /etc/apt/trusted.gpg.d/freexian-archive-extended-lts.gpg && \
+    echo "deb https://deb.freexian.com/extended-lts bullseye-lts main contrib" \
+      >> /etc/apt/sources.list
 
-ENV MOLTEN_VERSION 0.3.1
-ENV MOLTEN_MD5 04483620978a3167827bdd1424e34505
+# Now dist-upgrade and install all packages with both repos available
+RUN apt-get update && \
+    apt-get dist-upgrade -yq && \
+    apt-get install -yq --no-install-recommends \
+    locales ca-certificates curl \
+    systemd systemd-sysv dbus \
+    vim less net-tools procps lsb-release git patch \
+    openssh-client make gnupg sudo \
+    python3-apt python3-git python3-openssl \
+    python3-pip python3-setuptools python3-wheel python3-venv \
+    python3-zmq python3-msgpack python3-jinja2 python3-yaml \
+    python3-markupsafe python3-certifi python3-dateutil \
+    python3-requests python3-tornado python3-distro \
+    expect \
+    && localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8 \
+    && rm -rf /var/lib/apt/lists/*
+ENV LANG=en_US.utf8
+
+# Install Salt 3003 and dependencies via pip
+RUN pip3 install --no-cache-dir \
+    salt==3003 \
+    CherryPy \
+    https://github.com/salt-formulas/reclass/archive/v1.7.0.zip
+
+# Dirty fix issue https://github.com/saltstack/salt/issues/59990
+# (reverting: https://github.com/saltstack/salt/pull/59866)
+COPY salt_v3003_master_tops.patch /tmp/salt_v3003_master_tops.patch
+RUN patch /usr/local/lib/python3.9/dist-packages/salt/master.py /tmp/salt_v3003_master_tops.patch
+
+# Create salt systemd service (since we installed via pip, no service file is provided)
+RUN cat <<'EOF' > /etc/systemd/system/salt-master.service
+[Unit]
+Description=The Salt Master Server
+Documentation=man:salt-master(1) file:///usr/share/doc/salt/html/contents.html https://docs.saltproject.io/en/latest/contents.html
+After=network.target
+
+[Service]
+Type=simple
+LimitNOFILE=100000
+ExecStart=/usr/local/bin/salt-master
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+RUN cat <<'EOF' > /etc/systemd/system/salt-api.service
+[Unit]
+Description=The Salt API
+Documentation=man:salt-api(1) file:///usr/share/doc/salt/html/contents.html https://docs.saltproject.io/en/latest/contents.html
+After=network.target salt-master.service
+
+[Service]
+Type=simple
+LimitNOFILE=100000
+ExecStart=/usr/local/bin/salt-api
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+RUN systemctl enable salt-master.service salt-api.service
+
+# Set default target to multi-user (not graphical)
+RUN systemctl set-default multi-user.target
+
+# Mask unnecessary systemd services for container usage
+RUN systemctl mask \
+    dev-hugepages.mount \
+    sys-fs-fuse-connections.mount \
+    sys-kernel-config.mount \
+    display-manager.service \
+    getty@.service \
+    systemd-logind.service \
+    systemd-remount-fs.service \
+    getty.target \
+    graphical.target
+
+# Fix dbus OOMScoreAdjust (not allowed in containers)
+RUN cp /lib/systemd/system/dbus.service /etc/systemd/system/; \
+    sed -i 's/OOMScoreAdjust=.*//' /etc/systemd/system/dbus.service
+
+# Install entrypoint and service files
+COPY entry.sh /usr/bin/entry.sh
+RUN chmod +x /usr/bin/entry.sh
+COPY resin.service /etc/systemd/system/resin.service
+RUN systemctl enable /etc/systemd/system/resin.service
+
+COPY override.conf /etc/systemd/system/salt-master.service.d/override.conf
+COPY pre-salt-master.sh /usr/local/bin/pre-salt-master.sh
+RUN chmod +x /usr/local/bin/pre-salt-master.sh
+
+# Molten web UI
+ENV MOLTEN_VERSION=0.3.2
+ENV MOLTEN_MD5=4bce824944e6a2f5d09d703af53d596d
 ADD https://github.com/martinhoefling/molten/releases/download/v${MOLTEN_VERSION}/molten-${MOLTEN_VERSION}.tar.gz molten-${MOLTEN_VERSION}.tar.gz
-RUN echo "${MOLTEN_MD5}  molten-${MOLTEN_VERSION}.tar.gz" | md5sum --check
-RUN mkdir -p /opt/molten && tar -xf molten-${MOLTEN_VERSION}.tar.gz -C /opt/molten --strip-components=1
-
-ADD run.sh /run.sh
-RUN chmod a+x /run.sh
+RUN echo "${MOLTEN_MD5} molten-${MOLTEN_VERSION}.tar.gz" | md5sum --check && \
+    mkdir -p /opt/molten && tar -xf molten-${MOLTEN_VERSION}.tar.gz -C /opt/molten --strip-components=1 && \
+    rm -f molten-${MOLTEN_VERSION}.tar.gz
 
 # salt-master, salt-api
-EXPOSE 4505 4506 443
+EXPOSE 4505 4506 443 8000
 
-ENV SALT_CONFIG /etc/salt
-ENV BEFORE_EXEC_SCRIPT ${SALT_CONFIG}/before-exec.sh
-ENV SALT_API_CMD /usr/bin/salt-api -c ${SALT_CONFIG} -d
-ENV EXEC_CMD /usr/bin/salt-master -c ${SALT_CONFIG}  --log-file-level=quiet --log-level=debug
+ENV BEFORE_EXEC_SCRIPT=/etc/salt/before-exec.sh
 
-CMD ["/run.sh"]
+STOPSIGNAL 37
+ENTRYPOINT ["/usr/bin/entry.sh"]
+CMD ["/bin/date"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,37 @@
+services:
+  salt-master:
+    build: .
+    container_name: salt-master
+    hostname: salt-master
+    privileged: true
+    tmpfs:
+      - /run
+      - /run/lock
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+      - ./tests/salt/master.d/auto_accept.conf:/etc/salt/master.d/auto_accept.conf:ro
+      - ./tests/salt/master.d/reclass.conf:/etc/salt/master.d/reclass.conf:ro
+      - ./tests/salt/master.d/file_roots.conf:/etc/salt/master.d/file_roots.conf:ro
+      - ./tests/salt/states:/srv/salt/states:ro
+      - ./tests/salt/reclass:/srv/salt/reclass:ro
+    environment:
+      - INITSYSTEM=on
+    ports:
+      - "4505:4505"
+      - "4506:4506"
+
+  salt-minion:
+    image: bbinet/salt-minion:buster_3003
+    container_name: salt-minion
+    hostname: salt-minion
+    privileged: true
+    tmpfs:
+      - /run
+      - /run/lock
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+      - ./tests/salt/minion.d/master.conf:/etc/salt/minion.d/master.conf:ro
+    depends_on:
+      - salt-master
+    environment:
+      - INITSYSTEM=on

--- a/entry.sh
+++ b/entry.sh
@@ -1,0 +1,103 @@
+#!/bin/bash
+
+set -m
+
+# This command only works in privileged container
+if ip link add dummy0 type dummy &> /dev/null; then
+	PRIVILEGED=true
+	# clean the dummy0 link
+	ip link delete dummy0 &> /dev/null
+else
+	PRIVILEGED=false
+fi
+
+# Send SIGTERM to child processes of PID 1.
+function signal_handler()
+{
+	kill "$pid"
+}
+
+function mount_dev()
+{
+	tmp_dir='/tmp/tmpmount'
+	mkdir -p "$tmp_dir"
+	mount -t devtmpfs none "$tmp_dir"
+	mkdir -p "$tmp_dir/shm"
+	mount --move /dev/shm "$tmp_dir/shm"
+	mkdir -p "$tmp_dir/mqueue"
+	mount --move /dev/mqueue "$tmp_dir/mqueue"
+	mkdir -p "$tmp_dir/pts"
+	mount --move /dev/pts "$tmp_dir/pts"
+	touch "$tmp_dir/console"
+	mount --move /dev/console "$tmp_dir/console"
+	umount /dev || true
+	mount --move "$tmp_dir" /dev
+
+	# Since the devpts is mounted with -o newinstance by Docker, we need to make
+	# /dev/ptmx point to its ptmx.
+	# ref: https://www.kernel.org/doc/Documentation/filesystems/devpts.txt
+	ln -sf /dev/pts/ptmx /dev/ptmx
+	mount -t debugfs nodev /sys/kernel/debug || true
+}
+
+function init_systemd()
+{
+	GREEN='\033[0;32m'
+	echo -e "${GREEN}Systemd init system enabled."
+	for var in $(compgen -e); do
+		printf '%q=%q\n' "$var" "${!var}"
+	done > /etc/docker.env
+	echo 'source /etc/docker.env' >> ~/.bashrc
+
+	printf '#!/bin/bash\n exec ' > /etc/resinApp.sh
+	printf '%q ' "$@" >> /etc/resinApp.sh
+	chmod +x /etc/resinApp.sh
+
+	mkdir -p /etc/systemd/system/resin.service.d
+	cat <<-EOF > /etc/systemd/system/resin.service.d/override.conf
+		[Service]
+		WorkingDirectory=$(pwd)
+	EOF
+
+	sleep infinity &
+	exec env DBUS_SYSTEM_BUS_ADDRESS=unix:path=/run/dbus/system_bus_socket /sbin/init quiet systemd.show_status=0
+}
+
+function init_non_systemd()
+{
+	# trap the stop signal then send SIGTERM to user processes
+	trap signal_handler SIGRTMIN+3 SIGTERM
+
+	# echo error message, when executable file doesn't exist.
+	if CMD=$(command -v "$1" 2>/dev/null); then
+		shift
+		"$CMD" "$@" &
+		pid=$!
+		wait "$pid"
+		exit_code=$?
+		fg &> /dev/null || exit "$exit_code"
+	else
+		echo "Command not found: $1"
+		exit 1
+	fi
+}
+
+INITSYSTEM=${INITSYSTEM:-on}
+INITSYSTEM=$(echo "$INITSYSTEM" | awk '{print tolower($0)}')
+
+case "$INITSYSTEM" in
+	'1' | 'true')
+		INITSYSTEM='on'
+	;;
+esac
+
+if $PRIVILEGED; then
+	# Only run mount_dev in privileged container
+	mount_dev
+fi
+
+if [ "$INITSYSTEM" = "on" ]; then
+	init_systemd "$@"
+else
+	init_non_systemd "$@"
+fi

--- a/override.conf
+++ b/override.conf
@@ -1,0 +1,3 @@
+[Service]
+ExecStartPre=/usr/local/bin/pre-salt-master.sh
+TimeoutStartSec=300

--- a/pre-salt-master.sh
+++ b/pre-salt-master.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
-set -m
+# Import our environment variables from systemd
+while IFS= read -rd '' var; do export "$var"; done </proc/1/environ
 
 abort() {
     msg="$1"
@@ -47,38 +48,38 @@ if [ -n "${KEY_MASTER_PRIV}" ]; then
         abort "=> Both KEY_MASTER_PRIV and KEY_MASTER_PUB should be set."
     fi
     echo "=> Overwriting master public & private key"
-    mkdir -p "${SALT_CONFIG}/pki/master"
-    chmod 700 "${SALT_CONFIG}/pki/master"
-    echo -e "${KEY_MASTER_PRIV}" > "${SALT_CONFIG}/pki/master/master.pem"
-    echo -e "${KEY_MASTER_PUB}" > "${SALT_CONFIG}/pki/master/master.pub"
+    mkdir -p "/etc/salt/pki/master"
+    chmod 700 "/etc/salt/pki/master"
+    echo -e "${KEY_MASTER_PRIV}" > "/etc/salt/pki/master/master.pem"
+    echo -e "${KEY_MASTER_PUB}" > "/etc/salt/pki/master/master.pub"
 fi
 
 # create salt master keys from docker secrets
 if [ -f /run/secrets/master.pem ] && [ -f /run/secrets/master.pub ]
 then
-    mkdir -p "${SALT_CONFIG}/pki/master"
-    chmod 700 "${SALT_CONFIG}/pki/master"
+    mkdir -p "/etc/salt/pki/master"
+    chmod 700 "/etc/salt/pki/master"
     echo "=> Overwriting master public & private key from docker secrets"
-    cp /run/secrets/master.pem "${SALT_CONFIG}/pki/master/master.pem"
-    cp /run/secrets/master.pub "${SALT_CONFIG}/pki/master/master.pub"
+    cp /run/secrets/master.pem "/etc/salt/pki/master/master.pem"
+    cp /run/secrets/master.pub "/etc/salt/pki/master/master.pub"
 fi
 
-if [ -f "${SALT_CONFIG}/pki/master/master.pem" ]
+if [ -f "/etc/salt/pki/master/master.pem" ]
 then
     if [ -z "${PRE_ACCEPT_MINIONS}" ]; then
         echo "=> No minion key supplied: no minion key will be pre-accepted."
     else
         for minion in $(echo ${PRE_ACCEPT_MINIONS} | tr "," "\n"); do
-            mkdir -p "${SALT_CONFIG}/pki/master/minions"
+            mkdir -p "/etc/salt/pki/master/minions"
             minionkey_var="${minion//-/_}_KEY"
             if [ -f "/run/secrets/${minion}.pub" ]
             then
                 echo "=> Overwriting minion ${minion} key from docker secrets"
-                cp "/run/secrets/${minion}.pub" "${SALT_CONFIG}/pki/master/minions/${minion}"
+                cp "/run/secrets/${minion}.pub" "/etc/salt/pki/master/minions/${minion}"
             elif ! [ -z "${!minionkey_var}" ]
             then
                 echo "=> Overwriting minion ${minion} key from env variables"
-                echo -e "${!minionkey_var}" > "${SALT_CONFIG}/pki/master/minions/${minion}"
+                echo -e "${!minionkey_var}" > "/etc/salt/pki/master/minions/${minion}"
             else
                 abort "=> Failed to preaccept minion \"${minion}\"!"
             fi
@@ -86,6 +87,8 @@ then
     fi
 fi
 
+
+BEFORE_EXEC_SCRIPT=${BEFORE_EXEC_SCRIPT:-/etc/salt/before-exec.sh}
 if [ -x "${BEFORE_EXEC_SCRIPT%% *}" ]
 then
     echo "=> Running BEFORE_EXEC_SCRIPT [$BEFORE_EXEC_SCRIPT]..."
@@ -95,12 +98,3 @@ then
         abort "=> BEFORE_EXEC_SCRIPT [$BEFORE_EXEC_SCRIPT] has failed."
     fi
 fi
-
-if [ -n "$SALT_API_CMD" ]
-then
-    echo "=> Running SALT_API_CMD [$SALT_API_CMD]..."
-    $SALT_API_CMD
-fi
-
-echo "=> Running EXEC_CMD [$EXEC_CMD]..."
-exec $EXEC_CMD

--- a/resin.service
+++ b/resin.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Resin.io User Application
+
+[Service]
+EnvironmentFile=/etc/docker.env
+ExecStart=/etc/resinApp.sh
+StandardOutput=tty
+StandardError=tty
+TTYPath=/dev/console
+Restart=on-failure
+
+[Install]
+WantedBy=basic.target

--- a/salt_v3003_master_tops.patch
+++ b/salt_v3003_master_tops.patch
@@ -1,0 +1,22 @@
+diff --git a/salt/master.py b/salt/master.py
+index e33d76905d..cddc12efdd 100644
+--- a/salt/master.py
++++ b/salt/master.py
+@@ -1204,6 +1204,7 @@ class AESFuncs(TransportMethods):
+     expose_methods = (
+         "verify_minion",
+         "_master_tops",
++        "_ext_nodes",
+         "_master_opts",
+         "_mine_get",
+         "_mine",
+@@ -1428,6 +1429,9 @@ class AESFuncs(TransportMethods):
+             return {}
+         return self.masterapi._master_tops(load, skip_verify=True)
+
++    # Needed so older minions can request master_tops
++    _ext_nodes = _master_tops
++
+     def _master_opts(self, load):
+         """
+         Return the master options to the minion

--- a/tests/run_integration_tests.sh
+++ b/tests/run_integration_tests.sh
@@ -1,0 +1,109 @@
+#!/bin/bash
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+COMPOSE="docker compose -f ${PROJECT_DIR}/docker-compose.yml"
+
+cleanup() {
+    echo "==> Cleaning up..."
+    $COMPOSE down -v --remove-orphans 2>/dev/null || true
+}
+trap cleanup EXIT
+
+echo "==> Building salt-master image..."
+$COMPOSE build salt-master
+
+echo "==> Pulling salt-minion image..."
+docker pull bbinet/salt-minion:buster_3003
+
+echo "==> Starting services..."
+$COMPOSE up -d
+
+echo "==> Waiting for salt-master to be ready..."
+RETRIES=60
+for i in $(seq 1 $RETRIES); do
+    if $COMPOSE exec -T salt-master salt-run manage.status 2>/dev/null | grep -q "up" 2>/dev/null; then
+        break
+    fi
+    # Also check if salt-master process is running
+    if $COMPOSE exec -T salt-master pgrep -f "salt-master" >/dev/null 2>&1; then
+        if [ $i -ge 15 ]; then
+            # After 15s, salt-master should be ready enough
+            break
+        fi
+    fi
+    echo "    Waiting for salt-master... ($i/$RETRIES)"
+    sleep 2
+done
+
+echo "==> Waiting for salt-minion to connect..."
+RETRIES=60
+for i in $(seq 1 $RETRIES); do
+    MINIONS=$($COMPOSE exec -T salt-master salt-key -l accepted --out=json 2>/dev/null || echo "{}")
+    if echo "$MINIONS" | grep -q "salt-minion"; then
+        echo "    Minion 'salt-minion' accepted!"
+        break
+    fi
+    echo "    Waiting for minion to be accepted... ($i/$RETRIES)"
+    sleep 3
+done
+
+# Give the minion a moment to fully connect after key acceptance
+sleep 5
+
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+run_test() {
+    local test_name="$1"
+    local test_cmd="$2"
+    local expect_pattern="$3"
+
+    echo ""
+    echo "=== TEST: $test_name ==="
+    OUTPUT=$(eval "$test_cmd" 2>&1) || true
+    echo "$OUTPUT"
+
+    if echo "$OUTPUT" | grep -q "$expect_pattern"; then
+        echo "--- PASS: $test_name ---"
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+    else
+        echo "--- FAIL: $test_name ---"
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+    fi
+}
+
+# Test 1: test.ping
+run_test "test.ping" \
+    "$COMPOSE exec -T salt-master salt '*' test.ping --out=json --timeout=30" \
+    "true"
+
+# Test 2: Check Freexian LTS repo is configured in the master
+run_test "Freexian LTS repo present" \
+    "$COMPOSE exec -T salt-master cat /etc/apt/sources.list" \
+    "deb.freexian.com/extended-lts"
+
+# Test 3: Reclass ext_pillar delivers pillar data
+run_test "Reclass ext_pillar delivers motd_message" \
+    "$COMPOSE exec -T salt-master salt 'salt-minion' pillar.get motd_message --out=json --timeout=30" \
+    "Hello from Reclass ext_pillar"
+
+# Test 4: state.highstate applies successfully
+run_test "state.highstate succeeds" \
+    "$COMPOSE exec -T salt-master salt '*' state.highstate --out=json --timeout=120" \
+    "Succeeded"
+
+# Test 5: Verify /etc/motd was created with reclass pillar content
+run_test "motd file created with reclass pillar content" \
+    "$COMPOSE exec -T salt-minion cat /etc/motd" \
+    "Hello from Reclass ext_pillar"
+
+echo ""
+echo "==============================="
+echo "Results: $TESTS_PASSED passed, $TESTS_FAILED failed"
+echo "==============================="
+
+if [ $TESTS_FAILED -gt 0 ]; then
+    exit 1
+fi

--- a/tests/salt/master.d/auto_accept.conf
+++ b/tests/salt/master.d/auto_accept.conf
@@ -1,0 +1,1 @@
+auto_accept: True

--- a/tests/salt/master.d/file_roots.conf
+++ b/tests/salt/master.d/file_roots.conf
@@ -1,0 +1,3 @@
+file_roots:
+  base:
+    - /srv/salt/states

--- a/tests/salt/master.d/reclass.conf
+++ b/tests/salt/master.d/reclass.conf
@@ -1,0 +1,13 @@
+master_tops:
+  reclass:
+    storage_type: yaml_fs
+    inventory_base_uri: /srv/salt/reclass
+
+ext_pillar:
+  - reclass:
+      storage_type: yaml_fs
+      inventory_base_uri: /srv/salt/reclass
+
+reclass: &reclass
+  storage_type: yaml_fs
+  inventory_base_uri: /srv/salt/reclass

--- a/tests/salt/minion.d/master.conf
+++ b/tests/salt/minion.d/master.conf
@@ -1,0 +1,1 @@
+master: salt-master

--- a/tests/salt/reclass/classes/default.yml
+++ b/tests/salt/reclass/classes/default.yml
@@ -1,0 +1,4 @@
+classes: []
+
+parameters:
+  motd_message: "Hello from Reclass ext_pillar!"

--- a/tests/salt/reclass/nodes/salt-minion.yml
+++ b/tests/salt/reclass/nodes/salt-minion.yml
@@ -1,0 +1,6 @@
+classes:
+  - default
+
+parameters:
+  _param:
+    environment: integration-test

--- a/tests/salt/states/motd.sls
+++ b/tests/salt/states/motd.sls
@@ -1,0 +1,5 @@
+/etc/motd:
+  file.managed:
+    - contents: |
+        {{ pillar.get('motd_message', 'Welcome') }}
+        Managed by Salt + Reclass

--- a/tests/salt/states/test_pkg.sls
+++ b/tests/salt/states/test_pkg.sls
@@ -1,0 +1,2 @@
+curl:
+  pkg.installed

--- a/tests/salt/states/top.sls
+++ b/tests/salt/states/top.sls
@@ -1,0 +1,4 @@
+base:
+  '*':
+    - motd
+    - test_pkg


### PR DESCRIPTION
## Summary
This PR modernizes the salt-master Docker image by upgrading from Debian Jessie to Bullseye, migrating from Salt 2016.11 to Salt 3003, and switching to systemd as the init system. The image now uses pip for Salt installation and includes proper systemd service files for production-ready container deployments.

## Key Changes

- **Base OS Upgrade**: Debian Jessie → Bullseye with Freexian Extended LTS repository for security updates
- **Salt Version**: 2016.11 → 3003 (installed via pip3 instead of apt)
- **Init System**: Replaced custom shell script with systemd-based initialization
- **Python**: Python 2 → Python 3 (all dependencies updated to python3-* packages)
- **Service Management**: Created proper systemd service files for salt-master and salt-api
- **Entrypoint**: New `entry.sh` script that handles both systemd and non-systemd container modes
- **Reclass Integration**: Updated to reclass v1.7.0 installed via pip with proper ext_pillar configuration
- **Molten UI**: Updated from v0.3.1 to v0.3.2
- **Testing**: Added comprehensive integration test suite with docker-compose setup

## Notable Implementation Details

- Added Freexian Extended LTS repository configuration to ensure security updates for EOL Bullseye
- Implemented a patch for Salt 3003 to fix master_tops compatibility issue (#59990)
- Created systemd service files with proper dependencies and resource limits
- Masked unnecessary systemd services for container-optimized operation
- Fixed dbus OOMScoreAdjust configuration for container compatibility
- Pre-salt-master.sh now imports environment variables from systemd
- Added comprehensive integration tests validating Salt master/minion communication, reclass ext_pillar delivery, and state application
- Docker Compose setup for local testing with salt-minion integration

https://claude.ai/code/session_01Afsa1PyWAe7i7G24NcUnym